### PR TITLE
Remove Babel, support Node v7.6.0 and higher

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-	"presets": ["es2015"],
-	"plugins": [
-		"transform-async-to-generator",
-		"syntax-async-functions",
-		"add-module-exports"
-	]
-}

--- a/app.js
+++ b/app.js
@@ -1,0 +1,19 @@
+const Koa = require('koa');
+const router = require('./routes');
+const bodyParser = require('koa-bodyparser');
+
+const app = new Koa();
+
+app
+	.use(bodyParser())
+	.use(router.routes())
+	.use(router.allowedMethods());
+
+app.use(async (ctx, next) => {
+	const start = new Date();
+	await next();
+	const ms = new Date() - start;
+	console.log(`${ctx.method} ${ctx.url} - ${ms}ms`);
+});
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-require('babel-register');
-require('babel-polyfill');
-const app = require('./server');
-const db = require('./models');
-
-db.sequelize.sync().then(() => {
-	app.listen(3000);
-});

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "koa-sequelize-boilerplate",
   "version": "0.0.1",
   "description": "An opinionated RESTful boilerplate using KOA v2 and Sequelize.",
-  "main": "index.js",
+  "main": "server.js",
+  "engines": {
+    "node": ">=7.6.0"
+  },
   "scripts": {
-    "start": "nodemon index.js"
+    "start": "nodemon server.js"
   },
   "author": {
     "name": "Matthew Heck",
@@ -19,13 +22,6 @@
     "sequelize": "^4.0.0-1"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-core": "^6.14.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-syntax-async-functions": "^6.13.0",
-    "babel-plugin-transform-async-to-generator": "^6.8.0",
-    "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.14.0"
+    "nodemon": "^1.11.0"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,4 +5,4 @@ const users = require('./users');
 
 router.use('/users', users.routes());
 
-export default router;
+module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -40,4 +40,4 @@ users.delete('/:id', async (ctx, next) => {
 	await next();
 });
 
-export default users;
+module.exports = users;

--- a/server.js
+++ b/server.js
@@ -1,19 +1,6 @@
-const Koa = require('koa');
-const router = require('./routes');
-const bodyParser = require('koa-bodyparser');
+const app = require('./app');
+const db = require('./models');
 
-const app = new Koa();
-
-app
-	.use(bodyParser())
-	.use(router.routes());
-	.use(router.allowedMethods());
-
-app.use(async (ctx, next) => {
-	const start = new Date();
-	await next();
-	const ms = new Date() - start;
-	console.log(`${ctx.method} ${ctx.url} - ${ms}ms`);
+db.sequelize.sync().then(() => {
+	app.listen(3000);
 });
-
-export default app;


### PR DESCRIPTION
Removes all Babel requirements in favor of using native `await/async` support in Node v7.6.0 and higher.

Refactored module export syntax with the removal of Babel.