### PR TITLE
Add additional Koa libraries

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,19 +1,18 @@
 const Koa = require('koa');
 const router = require('./routes');
 const bodyParser = require('koa-bodyparser');
+const logger = require('koa-logger');
+koaqs(app);
 
 const app = new Koa();
 
+// Use the qs library instead of querystring to support nested objects.
+koaqs(app);
+
 app
+	.use(logger())
 	.use(bodyParser())
 	.use(router.routes())
 	.use(router.allowedMethods());
-
-app.use(async (ctx, next) => {
-	const start = new Date();
-	await next();
-	const ms = new Date() - start;
-	console.log(`${ctx.method} ${ctx.url} - ${ms}ms`);
-});
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "koa": "^2.3.0",
     "koa-bodyparser": "^4.2.0",
+    "koa-logger": "^3.0.1",
+    "koa-qs": "^2.0.0",
     "koa-router": "^7.2.1",
     "pg": "^7.0.2",
     "pg-hstore": "^2.3.2",


### PR DESCRIPTION
- Adds `koa-logger` and removes the custom equivalent middleware
- Adds `koa-qs` to provide support for nested objects in querystrings (Koa uses `querystring` by default, which lacks support for nested objects -- `koa-qs` allows for the use of `qs` instead, which does support this).